### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 A comprehensive MCP server that provides programmatic access to Xcode functionality, enabling AI assistants like Claude to create, build, test, and manage iOS/macOS projects directly.
 
+<a href="https://glama.ai/mcp/servers/@ebowwa/xcode-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ebowwa/xcode-mcp/badge" alt="Xcode Server MCP server" />
+</a>
+
 ## 🚀 Features
 
 ### Project Management


### PR DESCRIPTION
This PR adds a badge for the [Xcode MCP Server](https://glama.ai/mcp/servers/@ebowwa/xcode-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@ebowwa/xcode-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ebowwa/xcode-mcp/badge" alt="Xcode Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.